### PR TITLE
Send helpUrl & ownerUrl on install/update

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,3 +113,4 @@ Follows [semantic versioning](https://docs.npmjs.com/getting-started/semantic-ve
 * 1.6.7 Fix getBotData to not return all room data.
 * 1.6.8 Get a list of all active rooms.
 * 1.6.9 On client side, use window location for server url.
+* 1.6.10 Send ownerUrl and helpUrl on install / update.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/refocus-bdk",
-  "version": "1.6.9",
+  "version": "1.6.10",
   "description": "Utilities used by Refocus Bots to communicate with Refocus.",
   "scripts": {
     "lint": "eslint --ext=js --ext=jsx . ",

--- a/refocus-bdk-server.js
+++ b/refocus-bdk-server.js
@@ -375,7 +375,7 @@ module.exports = (config) => {
       name,
       displayName = '',
       url,
-      docsUrl = '',
+      helpUrl = '',
       ownerUrl = '',
       active = false,
       version = '1.0.0',
@@ -397,7 +397,7 @@ module.exports = (config) => {
         .field('name', name)
         .field('displayName', displayName)
         .field('url', url)
-        .field('docsUrl', docsUrl)
+        .field('helpUrl', helpUrl)
         .field('ownerUrl', ownerUrl)
         .field('active', active)
         .field('version', version)
@@ -444,7 +444,7 @@ module.exports = (config) => {
       name,
       displayName = '',
       url,
-      docsUrl = '',
+      helpUrl = '',
       ownerUrl = '',
       active = false,
       version = '1.0.0',
@@ -466,7 +466,7 @@ module.exports = (config) => {
         .field('name', name)
         .field('displayName', displayName)
         .field('url', url)
-        .field('docsUrl', docsUrl)
+        .field('helpUrl', helpUrl)
         .field('ownerUrl', ownerUrl)
         .field('active', active)
         .field('version', version)
@@ -1040,8 +1040,8 @@ module.exports = (config) => {
      */
     installOrUpdateBot: (packageJSON) => {
       const { metadata: { actions, data, settings },
-        name, url, version, displayName, docsUrl, ownerUrl } = packageJSON;
-      const bot = { name, url, docsUrl, ownerUrl, version, displayName, actions,
+        name, url, version, displayName, helpUrl, ownerUrl } = packageJSON;
+      const bot = { name, url, helpUrl, ownerUrl, version, displayName, actions,
         data, settings, ui: DEFAULT_UI_PATH, active: true };
 
       // try to update a bot

--- a/refocus-bdk-server.js
+++ b/refocus-bdk-server.js
@@ -373,8 +373,10 @@ module.exports = (config) => {
   function installBot(bot) {
     const {
       name,
-      displayName,
+      displayName = '',
       url,
+      docsUrl = '',
+      ownerUrl = '',
       active = false,
       version = '1.0.0',
       actions = [],
@@ -389,15 +391,14 @@ module.exports = (config) => {
         req.proxy(PROXY_URL);
       }
 
-      if (displayName) {
-        req.field('displayName', displayName);
-      }
-
       req
         .set('Content-Type', 'multipart/form-data')
         .set('Authorization', TOKEN)
         .field('name', name)
+        .field('displayName', displayName)
         .field('url', url)
+        .field('docsUrl', docsUrl)
+        .field('ownerUrl', ownerUrl)
         .field('active', active)
         .field('version', version)
         .field('actions', JSON.stringify(actions))
@@ -441,8 +442,10 @@ module.exports = (config) => {
   function updateBot(bot) {
     const {
       name,
-      displayName,
+      displayName = '',
       url,
+      docsUrl = '',
+      ownerUrl = '',
       active = false,
       version = '1.0.0',
       actions = [],
@@ -457,15 +460,14 @@ module.exports = (config) => {
         req.proxy(PROXY_URL);
       }
 
-      if (displayName) {
-        req.field('displayName', displayName);
-      }
-
       req
         .set('Content-Type', 'multipart/form-data')
         .set('Authorization', TOKEN)
         .field('name', name)
+        .field('displayName', displayName)
         .field('url', url)
+        .field('docsUrl', docsUrl)
+        .field('ownerUrl', ownerUrl)
         .field('active', active)
         .field('version', version)
         .field('actions', JSON.stringify(actions))
@@ -1038,8 +1040,8 @@ module.exports = (config) => {
      */
     installOrUpdateBot: (packageJSON) => {
       const { metadata: { actions, data, settings },
-        name, url, version, displayName } = packageJSON;
-      const bot = { name, url, version, displayName, actions,
+        name, url, version, displayName, docsUrl, ownerUrl } = packageJSON;
+      const bot = { name, url, docsUrl, ownerUrl, version, displayName, actions,
         data, settings, ui: DEFAULT_UI_PATH, active: true };
 
       // try to update a bot

--- a/tests/install.js
+++ b/tests/install.js
@@ -36,6 +36,8 @@ describe('New Bot Installation: ', () => {
         expect(installedBot.url).to.equal(bot.url);
         expect(installedBot.version).to.equal(bot.version);
         expect(installedBot.displayName).to.equal(bot.displayName);
+        expect(installedBot.helpUrl).to.equal(bot.helpUrl);
+        expect(installedBot.ownerUrl).to.equal(bot.ownerUrl);
         expect(installedBot.actions).to.deep.equal(bot.actions);
         done();
       })

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -111,6 +111,8 @@ const settings = [
 const bot = {
   name: 'IlikeBurrito',
   url: 'https://buritto-stand.com',
+  helpUrl: 'https://better-buritto-stand.com',
+  ownerUrl: 'https://buritto-stand-owner.com',
   active: true,
   version: '2.0.0',
   displayName: 'Insert Cool Nickname Here!',


### PR DESCRIPTION
Waiting on https://github.com/salesforce/refocus/pull/999 to be released

- Send helpUrl & ownerUrl on install/update bot