### PR TITLE
Cors issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,4 @@ Follows [semantic versioning](https://docs.npmjs.com/getting-started/semantic-ve
 * 1.6.6 Can filter Events by type.
 * 1.6.7 Fix getBotData to not return all room data.
 * 1.6.8 Get a list of all active rooms.
+* 1.6.9 On client side, use window location for server url.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/refocus-bdk",
-  "version": "1.6.8",
+  "version": "1.6.9",
   "description": "Utilities used by Refocus Bots to communicate with Refocus.",
   "scripts": {
     "lint": "eslint --ext=js --ext=jsx . ",

--- a/refocus-bdk-client.js
+++ b/refocus-bdk-client.js
@@ -166,7 +166,7 @@ function genericPost(route, obj, apiToken){
 } // genericPost
 
 module.exports = (config) => {
-  const SERVER = config.refocusUrl;
+  const SERVER = window.location.origin || config.refocusUrl;
   const TOKEN = config.token;
 
   /**


### PR DESCRIPTION
- Currently bots hosted on heroku are using "...hk..." as their refocusUrl, this is required on the backend but not on the UI side. Changing this to use the page origin "....internal...." will stop OPTIONS from being called and will cut the requests made by bots hosted on heroku from their UI by 50%