### PR TITLE
Emit event for when new rooms are created

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,5 +126,5 @@ Follows [semantic versioning](https://docs.npmjs.com/getting-started/semantic-ve
 * 1.6.17 getRoomTypes function.
 * 1.6.18 Return reject bug.
 * 1.6.19 Added log automatically to event.
-* 1.6.20 Added botname from config to event
-
+* 1.6.20 Added botname from config to event.
+* 1.6.21 Emit event for new room created.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/refocus-bdk",
-  "version": "1.6.20",
+  "version": "1.6.21",
   "description": "Utilities used by Refocus Bots to communicate with Refocus.",
   "scripts": {
     "lint": "eslint --ext=js --ext=jsx . ",

--- a/refocus-bdk-server.js
+++ b/refocus-bdk-server.js
@@ -312,8 +312,11 @@ module.exports = (config) => {
     const botEventAdd =
       'refocus.internal.realtime.bot.event.add';
 
-    socket.on(initalizeEventName, () => {
-      logger.info('Socket Initialized');
+    socket.on(initalizeEventName, (data) => {
+      const eventData = JSON.parse(data);
+      const room = eventData[initalizeEventName];
+      app.emit('refocus.internal.realtime.bot.namespace.initialize', room);
+      log.realtime('New Room', room);
     });
 
     socket.on(settingsChangedEventName, (data) => {


### PR DESCRIPTION
- Bots can listen for this realtime event so they are notified when a new room is created.
- Required for current story I am working on so botData can be initialized when the room is first created