### PR TITLE
Added check for server disconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,4 @@ Follows [semantic versioning](https://docs.npmjs.com/getting-started/semantic-ve
 * 1.8.0 Adding sorted by in get events and adding deactivate room
 * 1.9.0  Added ability to connect to realtime app.
 * 1.9.1  Added botId to clientside events.
+* 1.9.2 Added logic to reconnect when refocus terminates websocket connection

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/refocus-bdk",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Utilities used by Refocus Bots to communicate with Refocus.",
   "scripts": {
     "lint": "eslint --ext=js --ext=jsx . ",

--- a/refocus-bdk-server.js
+++ b/refocus-bdk-server.js
@@ -246,7 +246,6 @@ module.exports = (config) => {
     socket.on('disconnect', (reason) => {
       logger.info('Socket Disconnected');
       if (reason === 'io server disconnect') {
-        // the disconnection was initiated by the server, you need to reconnect manually
         socket.connect();
       }
     });

--- a/refocus-bdk-server.js
+++ b/refocus-bdk-server.js
@@ -243,8 +243,12 @@ module.exports = (config) => {
       logger.error('Socket auth error:', err)
     );
 
-    socket.on('disconnect', () => {
+    socket.on('disconnect', (reason) => {
       logger.info('Socket Disconnected');
+      if (reason === 'io server disconnect') {
+        // the disconnection was initiated by the server, you need to reconnect manually
+        socket.connect();
+      }
     });
   } // refocusConnectSocket
 

--- a/refocus-bdk-server.js
+++ b/refocus-bdk-server.js
@@ -244,7 +244,7 @@ module.exports = (config) => {
     );
 
     socket.on('disconnect', (reason) => {
-      logger.info('Socket Disconnected');
+      logger.info(`Socket Disconnected, reason: ${reason}`);
       if (reason === 'io server disconnect') {
         socket.connect();
       }


### PR DESCRIPTION
In the bdk we are seeing an issue where the websocket disconnects: 
`{"level":"error","message":"Socket auth error: operation timed out","timestamp":"2020-03-19 02:34:57"}`

When this error is logged the application does not attempt to reconnect. 
I have added a check which should prevent this behaviour