### PR TITLE
Adding getRoomTypeById

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,4 +136,5 @@ Follows [semantic versioning](https://docs.npmjs.com/getting-started/semantic-ve
 * 1.9.0  Added ability to connect to realtime app.
 * 1.9.1  Added botId to clientside events.
 * 1.9.2 Added logic to reconnect when refocus terminates websocket connection
-* 1.9.3 Added the isBotInstalledInRoom function.
+* 1.9.3 Added function isBotInstalledInRoom.
+* 1.9.4 Added function getRoomTypeById.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/refocus-bdk",
-  "version": "1.9.3",
+  "version": "1.9.4",
   "description": "Utilities used by Refocus Bots to communicate with Refocus.",
   "scripts": {
     "lint": "eslint --ext=js --ext=jsx . ",

--- a/refocus-bdk-server.js
+++ b/refocus-bdk-server.js
@@ -486,14 +486,27 @@ module.exports = (config) => {
   } // heartBeat
 
   /**
+   * Gets room type information
+   * @param {*} roomTypeId;
+   * @returns {object} Roomtype information
+   */
+  async function getRoomTypeById(roomTypeId) {
+    // eslint-disable-next-line max-len
+    const response = await generic.get(`${SERVER}${API}${ROOM_TYPES_ROUTE}/${roomTypeId}`,
+      TOKEN, DEFAULT_TRIES, null, PROXY_URL);
+    return response.body;
+  }
+
+  /**
    * Checks RoomType bot list for bot triggering event
    * @param {Object} event - refocusEvent
    * @param {String} bot - botName
    * @returns {boolean}
    */
-  function isBotInstalledInRoom(event, bot) {
-    const botsInRoom = event.Room.RoomType.Bots;
-    const botsInstalled = botsInRoom.find((b) => b.name === bot);
+  async function isBotInstalledInRoom(event, bot) {
+    const eventRoomTypeId = event.Room.RoomType.id;
+    const botsInRoomType = await getRoomTypeById(eventRoomTypeId);
+    const botsInstalled = botsInRoomType.bots.find((b) => b.name === bot);
     if (botsInstalled) {
       return true;
     }

--- a/refocus-bdk-server.js
+++ b/refocus-bdk-server.js
@@ -488,13 +488,20 @@ module.exports = (config) => {
   /**
    * Gets room type information
    * @param {*} roomTypeId;
-   * @returns {object} Roomtype information
+   * @returns {object} Roomtype information or null
    */
   async function getRoomTypeById(roomTypeId) {
-    // eslint-disable-next-line max-len
-    const response = await generic.get(`${SERVER}${API}${ROOM_TYPES_ROUTE}/${roomTypeId}`,
-      TOKEN, DEFAULT_TRIES, null, PROXY_URL);
-    return response.body;
+    try {
+      if (roomTypeId) {
+        // eslint-disable-next-line max-len
+        const response = await generic.get(`${SERVER}${API}${ROOM_TYPES_ROUTE}/${roomTypeId}`,
+          TOKEN, DEFAULT_TRIES, null, PROXY_URL);
+        return response.body;
+      }
+    } catch (error) {
+      return null;
+    }
+    return null;
   }
 
   /**
@@ -505,12 +512,15 @@ module.exports = (config) => {
    */
   async function isBotInstalledInRoom(event, bot) {
     const eventRoomTypeId = event.Room.RoomType.id;
-    const botsInRoomType = await getRoomTypeById(eventRoomTypeId);
-    const botsInstalled = botsInRoomType.bots.find((b) => b.name === bot);
-    if (botsInstalled) {
-      return true;
+    try {
+      const botsInRoomType = await getRoomTypeById(eventRoomTypeId);
+      if (botsInRoomType) {
+        const botsInstalled = botsInRoomType.bots.find((b) => b === bot);
+        return Boolean(botsInstalled);
+      }
+    } catch (error) {
+      return false;
     }
-    return false;
   }
 
   return {
@@ -528,6 +538,7 @@ module.exports = (config) => {
     updateBot,
 
     isBotInstalledInRoom,
+    getRoomTypeById,
 
     /**
      * Find room by id/name

--- a/refocus-bdk-server.js
+++ b/refocus-bdk-server.js
@@ -499,6 +499,7 @@ module.exports = (config) => {
         return response.body;
       }
     } catch (error) {
+      log.error('failed return Roomtype data from Refocus:', error.message);
       return null;
     }
     return null;
@@ -518,7 +519,9 @@ module.exports = (config) => {
         const botsInstalled = botsInRoomType.bots.find((b) => b === bot);
         return Boolean(botsInstalled);
       }
+      return false;
     } catch (error) {
+      log.error('failed to get roomType:', error.message);
       return false;
     }
   }

--- a/tests/getRoomTypeById.js
+++ b/tests/getRoomTypeById.js
@@ -42,9 +42,17 @@ describe('getRoomTypeById', () => {
     expect(roomTypeBody.id).to.be.equal('e118e6f1-a6d5-4164-9c14-7344c733c3e6');
   });
 
-  it('OK should Fail on a bad request', async () => {
+  it('OK should fail when invalid id', async () => {
     getGenericRoomTypeStub.returns(Promise.resolve(roomType));
     const roomTypeBody = await bdk.getRoomTypeById();
+    // eslint-disable-next-line no-unused-expressions
+    expect(roomTypeBody).to.be.null;
+  });
+
+  it('OK should be null in when request fails', async () => {
+    getGenericRoomTypeStub.returns(Promise.resolve());
+    const roomTypeId = 'e118e6f1-a6d5-4164-9c14-7344c733c3e6';
+    const roomTypeBody = await bdk.getRoomTypeById(roomTypeId);
     // eslint-disable-next-line no-unused-expressions
     expect(roomTypeBody).to.be.null;
   });

--- a/tests/getRoomTypeById.js
+++ b/tests/getRoomTypeById.js
@@ -1,0 +1,51 @@
+
+/**
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
+
+const expect = require('chai').expect;
+const config = { refocusUrl: 'zzz', token: 'dummy' };
+// eslint-disable-next-line max-len
+const bdk = require('../refocus-bdk-server')(config);
+const generic = require('../generic');
+const sinon = require('sinon');
+
+const roomType = {
+  body: {
+    id: 'e118e6f1-a6d5-4164-9c14-7344c733c3e6',
+    name: 'test-room-type',
+    isEnabled: true,
+    bots: [
+      'test-bot'
+    ]
+  }
+};
+
+describe('getRoomTypeById', () => {
+  let getGenericRoomTypeStub;
+  beforeEach(() => {
+    getGenericRoomTypeStub = sinon.stub(generic, 'get');
+  });
+
+  afterEach(() => {
+    getGenericRoomTypeStub.restore();
+  });
+
+  it('OK if roomTypeId matches response', async () => {
+    getGenericRoomTypeStub.returns(Promise.resolve(roomType));
+    const roomTypeId = 'e118e6f1-a6d5-4164-9c14-7344c733c3e6';
+    const roomTypeBody = await bdk.getRoomTypeById(roomTypeId);
+    expect(roomTypeBody.id).to.be.equal('e118e6f1-a6d5-4164-9c14-7344c733c3e6');
+  });
+
+  it('OK should Fail on a bad request', async () => {
+    getGenericRoomTypeStub.returns(Promise.resolve(roomType));
+    const roomTypeBody = await bdk.getRoomTypeById();
+    // eslint-disable-next-line no-unused-expressions
+    expect(roomTypeBody).to.be.null;
+  });
+});

--- a/tests/isBotInstalled.js
+++ b/tests/isBotInstalled.js
@@ -1,49 +1,51 @@
 
-/**
- * Copyright (c) 2020, salesforce.com, inc.
- * All rights reserved.
- * Licensed under the BSD 3-Clause license.
- * For full license text, see LICENSE.txt file in the repo root or
- * https://opensource.org/licenses/BSD-3-Clause
- */
+// /**
+//  * Copyright (c) 2020, salesforce.com, inc.
+//  * All rights reserved.
+//  * Licensed under the BSD 3-Clause license.
+//  * For full license text, see LICENSE.txt file in the repo root or
+//  * https://opensource.org/licenses/BSD-3-Clause
+//  */
 
-const expect = require('chai').expect;
-const config = { refocusUrl: 'zzz', token: 'dummy' };
-const bdk = require('../refocus-bdk-server')(config);
+// const expect = require('chai').expect;
+// const config = { refocusUrl: 'zzz', token: 'dummy' };
+// const bdk = require('../refocus-bdk-server')(config);
+// const sinon = require('sinon');
+// const generic = require('../generic.js');
 
-const event = {
-  id: 'b44dc350-9706-4800-adb2-d0999152e408',
-  log: 'Room Deactivated',
-  actionType: null,
-  context: {
-    type: 'RoomState',
-    active: false
-  },
-  Room: {
-    id: 2,
-    name: 'testRoom',
-    RoomType: {
-      id: 'e118e6f1-a6d5-4164-9c14-7344c733c3e6',
-      name: 'testRoomType',
-      Bots: [
-        {
-          id: '6812d9f4-191d-48c0-abff-8c013a697c76',
-          name: 'test-bot'
-        }
-      ]
-    }
-  }
-};
+// const event = {
+//   id: 'b44dc350-9706-4800-adb2-d0999152e408',
+//   log: 'Room Deactivated',
+//   actionType: null,
+//   context: {
+//     type: 'RoomState',
+//     active: false
+//   },
+//   Room: {
+//     id: 2,
+//     name: 'testRoom',
+//     RoomType: {
+//       id: 'e118e6f1-a6d5-4164-9c14-7344c733c3e6',
+//       name: 'testRoomType',
+//       Bots: [
+//         {
+//           id: '6812d9f4-191d-48c0-abff-8c013a697c76',
+//           name: 'test-bot'
+//         }
+//       ]
+//     }
+//   }
+// };
 
-describe('BDK isBotInstalledInRoom:', () => {
-  it('Ok, returns true if bot in Room', () => {
-    const bot = 'test-bot';
-    const isBotInstalled = bdk.isBotInstalledInRoom(event, bot);
-    expect(isBotInstalled).to.equal(true);
-  });
-  it('Ok, returns false when bot not in Room', () => {
-    const bot = 'test-bot-b';
-    const isBotInstalled = bdk.isBotInstalledInRoom(event, bot);
-    expect(isBotInstalled).to.equal(false) ;
-  });
-});
+// // describe('BDK isBotInstalledInRoom:', () => {
+// //   it('Ok, returns true if bot in Room', () => {
+// //     const bot = 'test-bot';
+// //     const isBotInstalled = bdk.isBotInstalledInRoom(event, bot);
+// //     expect(isBotInstalled).to.equal(true);
+// //   });
+// //   it('Ok, returns false when bot not in Room', () => {
+// //     const bot = 'test-bot-b';
+// //     const isBotInstalled = bdk.isBotInstalledInRoom(event, bot);
+// //     expect(isBotInstalled).to.equal(false) ;
+// //   });
+// // });

--- a/tests/isBotInstalled.js
+++ b/tests/isBotInstalled.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-unused-expressions */
 
 // /**
 //  * Copyright (c) 2020, salesforce.com, inc.
@@ -7,45 +8,62 @@
 //  * https://opensource.org/licenses/BSD-3-Clause
 //  */
 
-// const expect = require('chai').expect;
-// const config = { refocusUrl: 'zzz', token: 'dummy' };
-// const bdk = require('../refocus-bdk-server')(config);
-// const sinon = require('sinon');
-// const generic = require('../generic.js');
+const expect = require('chai').expect;
+const config = { refocusUrl: 'zzz', token: 'dummy' };
+// eslint-disable-next-line max-len
+const bdk = require('../refocus-bdk-server')(config);
+const generic = require('../generic');
+const sinon = require('sinon');
 
-// const event = {
-//   id: 'b44dc350-9706-4800-adb2-d0999152e408',
-//   log: 'Room Deactivated',
-//   actionType: null,
-//   context: {
-//     type: 'RoomState',
-//     active: false
-//   },
-//   Room: {
-//     id: 2,
-//     name: 'testRoom',
-//     RoomType: {
-//       id: 'e118e6f1-a6d5-4164-9c14-7344c733c3e6',
-//       name: 'testRoomType',
-//       Bots: [
-//         {
-//           id: '6812d9f4-191d-48c0-abff-8c013a697c76',
-//           name: 'test-bot'
-//         }
-//       ]
-//     }
-//   }
-// };
+const event = {
+  id: 'b44dc350-9706-4800-adb2-d0999152e408',
+  Room: {
+    id: 2,
+    name: 'testRoom',
+    RoomType: {
+      id: 'e118e6f1-a6d5-4164-9c14-7344c733c3e6',
+      name: 'testRoomType'
+    }
+  }
+};
 
-// // describe('BDK isBotInstalledInRoom:', () => {
-// //   it('Ok, returns true if bot in Room', () => {
-// //     const bot = 'test-bot';
-// //     const isBotInstalled = bdk.isBotInstalledInRoom(event, bot);
-// //     expect(isBotInstalled).to.equal(true);
-// //   });
-// //   it('Ok, returns false when bot not in Room', () => {
-// //     const bot = 'test-bot-b';
-// //     const isBotInstalled = bdk.isBotInstalledInRoom(event, bot);
-// //     expect(isBotInstalled).to.equal(false) ;
-// //   });
-// // });
+const roomType = {
+  body: {
+    id: 'e118e6f1-a6d5-4164-9c14-7344c733c3e6',
+    name: 'test-room-type',
+    isEnabled: true,
+    bots: [
+      'test-bot'
+    ]
+  }
+};
+
+describe('IsBotInstalledInRoom', () => {
+  let getRoomTypeByIdStub;
+  let getGenericRoomTypeStub;
+  beforeEach(() => {
+    getGenericRoomTypeStub = sinon.stub(generic, 'get');
+    getRoomTypeByIdStub = sinon.stub(bdk, 'getRoomTypeById');
+  });
+
+  afterEach(() => {
+    getRoomTypeByIdStub.restore();
+    getGenericRoomTypeStub.restore();
+  });
+
+  it('true if Bot is listed in RoomType', async () => {
+    getGenericRoomTypeStub.returns(Promise.resolve(roomType));
+    getRoomTypeByIdStub.returns(Promise.resolve(roomType));
+    const botName = 'test-bot';
+    const isBotInstalled = await bdk.isBotInstalledInRoom(event, botName);
+    expect(isBotInstalled).to.be.true;
+  });
+
+  it('OK false if bot not roomType ', async () => {
+    getGenericRoomTypeStub.returns(Promise.resolve(roomType));
+    getRoomTypeByIdStub.returns(Promise.resolve(roomType));
+    const botName = 'robot';
+    const isBotInstalled = await bdk.isBotInstalledInRoom(event, botName);
+    expect(isBotInstalled).to.be.false;
+  });
+});

--- a/tests/isBotInstalled.js
+++ b/tests/isBotInstalled.js
@@ -39,21 +39,17 @@ const roomType = {
 };
 
 describe('IsBotInstalledInRoom', () => {
-  let getRoomTypeByIdStub;
   let getGenericRoomTypeStub;
   beforeEach(() => {
     getGenericRoomTypeStub = sinon.stub(generic, 'get');
-    getRoomTypeByIdStub = sinon.stub(bdk, 'getRoomTypeById');
   });
 
   afterEach(() => {
-    getRoomTypeByIdStub.restore();
     getGenericRoomTypeStub.restore();
   });
 
   it('true if Bot is listed in RoomType', async () => {
     getGenericRoomTypeStub.returns(Promise.resolve(roomType));
-    getRoomTypeByIdStub.returns(Promise.resolve(roomType));
     const botName = 'test-bot';
     const isBotInstalled = await bdk.isBotInstalledInRoom(event, botName);
     expect(isBotInstalled).to.be.true;
@@ -61,7 +57,6 @@ describe('IsBotInstalledInRoom', () => {
 
   it('OK false if bot not roomType ', async () => {
     getGenericRoomTypeStub.returns(Promise.resolve(roomType));
-    getRoomTypeByIdStub.returns(Promise.resolve(roomType));
     const botName = 'robot';
     const isBotInstalled = await bdk.isBotInstalledInRoom(event, botName);
     expect(isBotInstalled).to.be.false;
@@ -79,7 +74,6 @@ describe('IsBotInstalledInRoom', () => {
       }
     };
     getGenericRoomTypeStub.returns(Promise.resolve(invalidRoomType));
-    getRoomTypeByIdStub.returns(Promise.resolve(invalidRoomType));
     const botName = 'robot';
     const isBotInstalled = await bdk.isBotInstalledInRoom(event, botName);
     expect(isBotInstalled).to.be.false;
@@ -88,7 +82,6 @@ describe('IsBotInstalledInRoom', () => {
   it('OK false if roomType is null ', async () => {
     const invalidRoomType = null;
     getGenericRoomTypeStub.returns(Promise.resolve(invalidRoomType));
-    getRoomTypeByIdStub.returns(Promise.resolve(invalidRoomType));
     const botName = 'robot';
     const isBotInstalled = await bdk.isBotInstalledInRoom(event, botName);
     expect(isBotInstalled).to.be.false;

--- a/tests/isBotInstalled.js
+++ b/tests/isBotInstalled.js
@@ -1,12 +1,12 @@
 /* eslint-disable no-unused-expressions */
 
-// /**
-//  * Copyright (c) 2020, salesforce.com, inc.
-//  * All rights reserved.
-//  * Licensed under the BSD 3-Clause license.
-//  * For full license text, see LICENSE.txt file in the repo root or
-//  * https://opensource.org/licenses/BSD-3-Clause
-//  */
+/**
+ * Copyright (c) 2020, salesforce.com, inc.
+ * All rights reserved.
+ * Licensed under the BSD 3-Clause license.
+ * For full license text, see LICENSE.txt file in the repo root or
+ * https://opensource.org/licenses/BSD-3-Clause
+ */
 
 const expect = require('chai').expect;
 const config = { refocusUrl: 'zzz', token: 'dummy' };
@@ -62,6 +62,33 @@ describe('IsBotInstalledInRoom', () => {
   it('OK false if bot not roomType ', async () => {
     getGenericRoomTypeStub.returns(Promise.resolve(roomType));
     getRoomTypeByIdStub.returns(Promise.resolve(roomType));
+    const botName = 'robot';
+    const isBotInstalled = await bdk.isBotInstalledInRoom(event, botName);
+    expect(isBotInstalled).to.be.false;
+  });
+
+  it('OK false if roomType is invalid ', async () => {
+    const invalidRoomType = {
+      body: {
+        id: 'e118e6f1-a6d5-4164-9c14-7344c733c3e6',
+        name: 'test-room-type',
+        isEnabled: true,
+        Wrongbots: [
+          'test-bot'
+        ]
+      }
+    };
+    getGenericRoomTypeStub.returns(Promise.resolve(invalidRoomType));
+    getRoomTypeByIdStub.returns(Promise.resolve(invalidRoomType));
+    const botName = 'robot';
+    const isBotInstalled = await bdk.isBotInstalledInRoom(event, botName);
+    expect(isBotInstalled).to.be.false;
+  });
+
+  it('OK false if roomType is null ', async () => {
+    const invalidRoomType = null;
+    getGenericRoomTypeStub.returns(Promise.resolve(invalidRoomType));
+    getRoomTypeByIdStub.returns(Promise.resolve(invalidRoomType));
     const botName = 'robot';
     const isBotInstalled = await bdk.isBotInstalledInRoom(event, botName);
     expect(isBotInstalled).to.be.false;


### PR DESCRIPTION

### Description
we need to get the list of bots in a room from the RoomType as that list is truncated on the Event. Hence I've added a new function to get roomType data based on roomTypeId from a refocus event. That allows to check if a bot is included on a Room from the roomTypeID. 

---

* Once this is merged and released I'll open another PR to ttx-bot to add the check back on the EventHandler.

* Tested on local Refocus was able to confirm it works on this small isolated environment. 




