### PR TITLE
Redis password patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,4 +139,5 @@ Follows [semantic versioning](https://docs.npmjs.com/getting-started/semantic-ve
 * 1.9.3 Added function isBotInstalledInRoom.
 * 1.9.4 Added function getRoomTypeById.
 * 1.9.5 Added function getRoomById, removed getRoomTypeById.
-* 1.10.0 Added optional support for multiple instances of bots (requires redis instance)
+* 1.10.0 Added optional support for multiple instances of bots (requires redis instance).
+* 1.10.1 Added password option to cache initialisation for authentication.

--- a/cache/CacheFactory.js
+++ b/cache/CacheFactory.js
@@ -12,15 +12,16 @@ class CacheFactory {
    * @param {object} logger - instance of logger
    * @param {string?} host - host to reach cache at (overrides default)
    * @param {number?} port - port to reach cache on (overrides default)
+   * @param {string?} password - password for redis cache
    * @returns {object} - connection to cache | null
    */
-  async build(type, logger, host = null, port = null) {
+  async build(type, logger, host = null, port = null, password) {
     let instance;
     let builtSuccessfully = false;
     switch (type) {
       case this.clientTypes.REDIS: {
         instance = new Redis();
-        builtSuccessfully = await instance.build(logger, host, port);
+        builtSuccessfully = await instance.build(logger, host, port, password);
         break;
       }
 

--- a/cache/Redis.js
+++ b/cache/Redis.js
@@ -2,11 +2,13 @@ const redis = require('redis');
 const defaultHost = '127.0.0.1';
 const defaultPort = 6379;
 const timeToLiveInSeconds = 60;
+const defaultPassword = '';
 
 class Redis {
-  build (logger, host = defaultHost, port = defaultPort) {
+  build (logger, host = defaultHost, port = defaultPort,
+    password = defaultPassword) {
     return new Promise((resolve) => {
-      this.client = redis.createClient({ host, port });
+      this.client = redis.createClient({ host, port, password });
       this.logger = logger;
       this.client.on('error', (error) => {
         this.logger.error(error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/refocus-bdk",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Utilities used by Refocus Bots to communicate with Refocus.",
   "scripts": {
     "lint": "eslint --ext=js --ext=jsx . ",

--- a/refocus-bdk-server.js
+++ b/refocus-bdk-server.js
@@ -168,11 +168,12 @@ module.exports = (config) => {
   // Create connection to redis for caching (if enabled)
   let cache;
   if (config.useRedisCache) {
-    const { redisCacheHost, redisCachePort } = config;
+    const { redisCacheHost, redisCachePort, redisCachePassword } = config;
     if (redisCacheHost && redisCachePort) {
       const cacheFactory = new CacheFactory();
       const REDIS = cacheFactory.clientTypes.REDIS;
-      cacheFactory.build(REDIS, logger, redisCacheHost, redisCachePort)
+      cacheFactory.build(REDIS, logger, redisCacheHost,
+        redisCachePort, redisCachePassword)
         .then((client) => {
           cache = client;
         })


### PR DESCRIPTION
For production the bots need to be able to authenticate to the redis instance. 

- ## cache/CacheFactory.js
   - Added password parameter to build function 
   - Build function provides password to instance build function

- ## cache/Redis.js
  - Updated build function to take in password, or use default password value of empty string.

- ## refocus-bdk-server.js
  - import password from config 
  - provides password to factory creation method