### PR TITLE
Change from using host and port to URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,4 @@ Follows [semantic versioning](https://docs.npmjs.com/getting-started/semantic-ve
 * 1.10.0 Added optional support for multiple instances of bots (requires redis instance).
 * 1.10.1 Added password option to cache initialisation for authentication.
 * 1.10.2 Fixed bug in cache checking, when cache is not enabled.
+* 1.10.3 Changed redis cache settings from host and port to url.

--- a/cache/CacheFactory.js
+++ b/cache/CacheFactory.js
@@ -10,18 +10,17 @@ class CacheFactory {
    *
    * @param {string} type - one of the implemented clientTypes
    * @param {object} logger - instance of logger
-   * @param {string?} host - host to reach cache at (overrides default)
-   * @param {number?} port - port to reach cache on (overrides default)
+   * @param {string?} url - url to reach cache at (overrides default)
    * @param {string?} password - password for redis cache
    * @returns {object} - connection to cache | null
    */
-  async build(type, logger, host = null, port = null, password) {
+  async build(type, logger, url, password) {
     let instance;
     let builtSuccessfully = false;
     switch (type) {
       case this.clientTypes.REDIS: {
         instance = new Redis();
-        builtSuccessfully = await instance.build(logger, host, port, password);
+        builtSuccessfully = await instance.build(logger, url, password);
         break;
       }
 

--- a/cache/Redis.js
+++ b/cache/Redis.js
@@ -1,5 +1,5 @@
 const redis = require('redis');
-const defaultUrl = 'redis://127.0.0.1:6379';
+const defaultUrl = 'redis://127.0.0.1:6379/0';
 const timeToLiveInSeconds = 60;
 const defaultPassword = '';
 

--- a/cache/Redis.js
+++ b/cache/Redis.js
@@ -2,16 +2,19 @@ const redis = require('redis');
 const defaultUrl = 'redis://127.0.0.1:6379/0';
 const timeToLiveInSeconds = 60;
 const defaultPassword = '';
+const MAX_RETRIES = 3;
 
 class Redis {
   build (logger, url = defaultUrl,
     password = defaultPassword) {
+    let errors = 0;
     return new Promise((resolve) => {
       this.client = redis.createClient({ url, password });
       this.logger = logger;
       this.client.on('error', (error) => {
         this.logger.error(error);
-        resolve(false);
+        errors++;
+        if (errors > MAX_RETRIES) resolve(false);
       });
 
       this.client.on('ready', () => {

--- a/cache/Redis.js
+++ b/cache/Redis.js
@@ -1,14 +1,13 @@
 const redis = require('redis');
-const defaultHost = '127.0.0.1';
-const defaultPort = 6379;
+const defaultUrl = 'redis://127.0.0.1:6379';
 const timeToLiveInSeconds = 60;
 const defaultPassword = '';
 
 class Redis {
-  build (logger, host = defaultHost, port = defaultPort,
+  build (logger, url = defaultUrl,
     password = defaultPassword) {
     return new Promise((resolve) => {
-      this.client = redis.createClient({ host, port, password });
+      this.client = redis.createClient({ url, password });
       this.logger = logger;
       this.client.on('error', (error) => {
         this.logger.error(error);
@@ -16,7 +15,7 @@ class Redis {
       });
 
       this.client.on('ready', () => {
-        this.logger.info(`Connected to redis at ${host}:${port}`);
+        this.logger.info(`Connected to redis at ${url}`);
         resolve(true);
       });
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@salesforce/refocus-bdk",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Utilities used by Refocus Bots to communicate with Refocus.",
   "scripts": {
     "lint": "eslint --ext=js --ext=jsx . ",

--- a/refocus-bdk-server.js
+++ b/refocus-bdk-server.js
@@ -168,12 +168,11 @@ module.exports = (config) => {
   // Create connection to redis for caching (if enabled)
   let cache;
   if (config.useRedisCache) {
-    const { redisCacheHost, redisCachePort, redisCachePassword } = config;
-    if (redisCacheHost && redisCachePort) {
+    const { redisCacheUrl, redisCachePassword } = config;
+    if (redisCacheUrl) {
       const cacheFactory = new CacheFactory();
       const REDIS = cacheFactory.clientTypes.REDIS;
-      cacheFactory.build(REDIS, logger, redisCacheHost,
-        redisCachePort, redisCachePassword)
+      cacheFactory.build(REDIS, logger, redisCacheUrl, redisCachePassword)
         .then((client) => {
           cache = client;
         })

--- a/tests/cache.js
+++ b/tests/cache.js
@@ -18,6 +18,7 @@ const logger = new winston.Logger();
    */
 async function testCache(cache, done) {
   const timestamp = new Date().toString();
+  expect(cache).to.not.equal(null);
   const shouldNotExist = await cache.hasBeenConsumed(timestamp)
     .catch(done);
   expect(shouldNotExist).to.equal(false);
@@ -49,7 +50,7 @@ describe('Testing cache creation', () => {
   it('Returns null when connection to redis cannot be established', (done) => {
     const cacheFactory = new CacheFactory();
     const redisClientType = cacheFactory.clientTypes.REDIS;
-    cacheFactory.build(redisClientType, logger, '127.0.0.1', 5123)
+    cacheFactory.build(redisClientType, logger, 'redis://127.0.0.1:1000')
       .then((client) => {
         expect(client).to.equal(null);
         done();

--- a/tests/cache.js
+++ b/tests/cache.js
@@ -31,7 +31,7 @@ describe('Testing cache creation', () => {
   it('Creates redis cache', (done) => {
     const cacheFactory = new CacheFactory();
     cacheFactory.build(cacheFactory.clientTypes.REDIS,
-      logger, null, null).then((redisCache) => {
+      logger).then((redisCache) => {
       testCache(redisCache, done);
     }).catch((error) => {
       done(error);


### PR DESCRIPTION
To adjust for how URL is being provided, bdk will now take in the entire redis URL rather than PORT and HOSTNAME separately.

 